### PR TITLE
Simplify GitHub connection name in CodeStar configuration

### DIFF
--- a/codepipeline/codestar_github_connection.tf
+++ b/codepipeline/codestar_github_connection.tf
@@ -1,4 +1,4 @@
 resource "aws_codestarconnections_connection" "github_connection" {
-  name          = "${var.project_name}-GitHubConnection"
+  name          = "GitHubConnection"
   provider_type = "GitHub"
 }


### PR DESCRIPTION
Streamline the GitHub connection name in the CodeStar configuration for clarity.