### PR TITLE
Simplify CodeStar configuration and clean up CodePipeline settings

### DIFF
--- a/codepipeline/codepipeline.tf
+++ b/codepipeline/codepipeline.tf
@@ -26,7 +26,6 @@ resource "aws_codepipeline" "lambdius-constructum-continua-lambda-codepipeline" 
         ConnectionArn        = aws_codestarconnections_connection.github_connection.arn
         FullRepositoryId     = var.lambda_functions_repo
         BranchName           = "Buildspec-Edits"
-        OutputArtifactFormat = "CODEPIPELINE"
       }
     }
   }
@@ -49,16 +48,6 @@ resource "aws_codepipeline" "lambdius-constructum-continua-lambda-codepipeline" 
           {
             name  = "SHARED_ARTIFACTS_BUCKET"
             value = var.shared_artifacts_bucket
-            type  = "PLAINTEXT"
-          },
-          {
-            name  = "COMMIT_ID"
-            value = "#{Source.SourceIdentifier.CommitId}"
-            type  = "PLAINTEXT"
-          },
-          {
-            name  = "PREVIOUS_COMMIT_ID"
-            value = "#{Source.SourceIdentifier.PreviousCommitId}"
             type  = "PLAINTEXT"
           }
         ])

--- a/codepipeline/codestar_github_connection.tf
+++ b/codepipeline/codestar_github_connection.tf
@@ -1,4 +1,4 @@
 resource "aws_codestarconnections_connection" "github_connection" {
-  name          = "${var.project_name}-GitHubConnection"
+  name          = "GitHubConnection"
   provider_type = "GitHub"
 }


### PR DESCRIPTION
Streamline the GitHub connection name in the CodeStar configuration and remove unnecessary OutputArtifactFormat from the CodePipeline configuration.